### PR TITLE
fix: Get rid of the weird scroll on start up

### DIFF
--- a/src/respec/sidebar.ts
+++ b/src/respec/sidebar.ts
@@ -4,139 +4,184 @@
  * https://www.w3.org/scripts/TR/2021/fixup.js
  */
 
-// @ts-nocheck
+const tocToggleId = "toc-toggle";
+const tocJumpId = "toc-jump";
+const tocCollapseId = "toc-collapse";
+const tocExpandId = "toc-expand";
 
-export default function () {
-
-const collapseSidebarText = '<span aria-hidden="true">←</span> '
-                        + '<span>Collapse Sidebar</span>';
-const expandSidebarText   = '<span aria-hidden="true">→</span> '
-                        + '<span>Pop Out Sidebar</span>';
-const tocJumpText         = '<span aria-hidden="true">↑</span> '
-                        + '<span>Jump to Table of Contents</span>';
-
-const sidebarMedia = window.matchMedia('screen and (min-width: 78em)');
-const autoToggle   = function(e){ toggleSidebar(e.matches) };
-if(sidebarMedia.addListener) {
-  sidebarMedia.addListener(autoToggle);
+interface CreatedElements {
+  /** The button that toggles ToC sidebar, `#{tocToggleId}` */
+  toggle: HTMLAnchorElement;
 }
 
-function toggleSidebar(on) {
-  if (on == undefined) {
-    on = !document.body.classList.contains('toc-sidebar');
+const t = {
+  collapseSidebar: "Collapse Sidebar",
+  expandSidebar: "Pop Out Sidebar",
+  jumpToToc: "Jump to Table of Contents",
+};
+const collapseSidebarText = '<span aria-hidden="true">←</span> ' +
+  `<span id="${tocCollapseId}-text">${t.collapseSidebar}</span>`;
+const expandSidebarText = '<span aria-hidden="true">→</span> ' +
+  `<span id="${tocExpandId}-text">${t.expandSidebar}</span>`;
+const tocJumpText = '<span aria-hidden="true">↑</span> ' +
+  `<span id="${tocJumpId}-text">${t.jumpToToc}</span>`;
+
+/** `true` means toc-sidebar, `false` means toc-inline */
+type SidebarStatus = boolean;
+
+/** Matches if default to toc-sidebar, does not match if default to toc-inline */
+const sidebarMedia = window.matchMedia("screen and (min-width: 78em)");
+
+function toggleSidebar(
+  { toggle }: CreatedElements,
+  /** `SidebarStatus` to select the desired status, `undefined` to toggle between them */
+  on: SidebarStatus | undefined = undefined,
+  /** Whether to force to skip scroll */
+  skipScroll: boolean = false,
+): SidebarStatus {
+  if (on === undefined) {
+    on = !document.body.classList.contains("toc-sidebar");
   }
 
-  /* Don't scroll to compensate for the ToC if we're above it already. */
-  let headY = 0;
-  const head = document.querySelector('.head');
-  if (head) {
-    // terrible approx of "top of ToC"
-    headY += head.offsetTop + head.offsetHeight;
+  if (!skipScroll) {
+    /* Don't scroll to compensate for the ToC if we're above it already. */
+    let headY = 0;
+    const head = document.querySelector<HTMLElement>(".head");
+    if (head) {
+      // terrible approx of "top of ToC"
+      headY += head.offsetTop + head.offsetHeight;
+    }
+    skipScroll = window.scrollY < headY;
   }
-  const skipScroll = window.scrollY < headY;
 
-  const toggle = document.getElementById('toc-toggle');
-  const tocNav = document.getElementById('toc');
+  const tocNav = document.getElementById("toc") as HTMLElement;
   if (on) {
-    const tocHeight = tocNav.offsetHeight;
-    document.body.classList.add('toc-sidebar');
-    document.body.classList.remove('toc-inline');
+    document.body.classList.add("toc-sidebar");
+    document.body.classList.remove("toc-inline");
+
     toggle.innerHTML = collapseSidebarText;
+    toggle.setAttribute("aria-labelledby", `${tocCollapseId}-text`);
+
     if (!skipScroll) {
+      const tocHeight = tocNav.offsetHeight;
       window.scrollBy(0, 0 - tocHeight);
     }
+
     tocNav.focus();
-    sidebarMedia.addListener(autoToggle); // auto-collapse when out of room
-  }
-  else {
-    document.body.classList.add('toc-inline');
-    document.body.classList.remove('toc-sidebar');
+  } else {
+    document.body.classList.add("toc-inline");
+    document.body.classList.remove("toc-sidebar");
+
     toggle.innerHTML = expandSidebarText;
+    toggle.setAttribute("aria-labelledby", `${tocExpandId}-text`);
+
     if (!skipScroll) {
       window.scrollBy(0, tocNav.offsetHeight);
     }
-    if (toggle.matches(':hover')) {
+
+    if (toggle.matches(":hover")) {
       /* Unfocus button when not using keyboard navigation,
-          because I don't know where else to send the focus. */
+         because I don't know where else to send the focus. */
       toggle.blur();
     }
   }
+
+  return on;
 }
 
-function createSidebarToggle() {
+function createSidebarToggle(): CreatedElements {
   /* Create the sidebar toggle in JS; it shouldn't exist when JS is off. */
-  const toggle = document.createElement('a');
-    /* This should probably be a button, but appearance isn't standards-track.*/
-  toggle.id = 'toc-toggle';
-  toggle.class = 'toc-toggle';
-  toggle.href = '#toc';
+  const toggle = document.createElement("a");
+  /* This should probably be a button, but appearance isn't standards-track.*/
+  toggle.id = tocToggleId;
+  toggle.classList.add("toc-toggle");
+  toggle.href = "#toc";
   toggle.innerHTML = collapseSidebarText;
-
-  sidebarMedia.addListener(autoToggle);
-  const toggler = function(e) {
-    e.preventDefault();
-    sidebarMedia.removeListener(autoToggle); // persist explicit off states
-    toggleSidebar();
-    return false;
-  }
-  toggle.addEventListener('click', toggler, false);
-
+  toggle.setAttribute("aria-labelledby", `${tocCollapseId}-text`);
 
   /* Get <nav id=toc-nav>, or make it if we don't have one. */
-  let tocNav = document.getElementById('toc-nav');
+  let tocNav = document.getElementById("toc-nav");
   if (!tocNav) {
-    tocNav = document.createElement('p');
-    tocNav.id = 'toc-nav';
+    tocNav = document.createElement("p");
+    tocNav.id = "toc-nav";
     /* Prepend for better keyboard navigation */
     document.body.insertBefore(tocNav, document.body.firstChild);
   }
+
   /* While we're at it, make sure we have a Jump to Toc link. */
-  let tocJump = document.getElementById('toc-jump');
+  let tocJump = document.getElementById(tocJumpId) as HTMLAnchorElement | null;
   if (!tocJump) {
-    tocJump = document.createElement('a');
-    tocJump.id = 'toc-jump';
-    tocJump.href = '#toc';
+    tocJump = document.createElement("a");
+    tocJump.id = tocJumpId;
+    tocJump.href = "#toc";
     tocJump.innerHTML = tocJumpText;
+    tocJump.setAttribute("aria-labelledby", `${tocJumpId}-text`);
     tocNav.appendChild(tocJump);
   }
 
   tocNav.appendChild(toggle);
+
+  return { toggle };
 }
 
-const toc = document.getElementById('toc');
-if (toc) {
-  createSidebarToggle();
-  toggleSidebar(sidebarMedia.matches);
+function setupToggleListener({ toggle }: CreatedElements): void {
+  const toggleToDefault = (e: MediaQueryListEvent): void => {
+    toggleSidebar({ toggle }, e.matches);
+  };
+
+  // Toggle the sidebar to the default state at start up
+  // Force to skip scroll because it will be the first view
+  toggleSidebar({ toggle }, sidebarMedia.matches, true);
+
+  // Listen to width changes, and auto-collapse when out of room
+  sidebarMedia.addEventListener("change", toggleToDefault);
+
+  // Toggle the sidebar when clicked
+  toggle.addEventListener("click", (e) => {
+    e.preventDefault();
+
+    // Persist explicit off states
+    sidebarMedia.removeEventListener("change", toggleToDefault);
+
+    // Toggle the sidebar
+    const finallyOn = toggleSidebar({ toggle });
+
+    // If the sidebar is finally on, auto-collapse when out of room later
+    if (finallyOn) {
+      sidebarMedia.addEventListener("change", toggleToDefault);
+    }
+
+    return false;
+  }, false);
+}
+
+export default function (): void {
+  const toc = document.getElementById("toc");
+  if (!toc) {
+    console.warn(
+      "Can't find Table of Contents. Please use <nav id='toc'> around the ToC.",
+    );
+    return;
+  }
+
+  const created = createSidebarToggle();
+  setupToggleListener(created);
 
   /* If the sidebar has been manually opened and is currently overlaying the text
-      (window too small for the MQ to add the margin to body),
-      then auto-close the sidebar once you click on something in there. */
-  toc.addEventListener('click', function(e) {
-    if(document.body.classList.contains('toc-sidebar') && !sidebarMedia.matches) {
-      let el = e.target;
+     (window too small for the MQ to add the margin to body),
+     then auto-close the sidebar once you click on something in there. */
+  toc.addEventListener("click", (e) => {
+    if (
+      document.body.classList.contains("toc-sidebar") && !sidebarMedia.matches
+    ) {
+      let el = e.target as HTMLElement;
       while (el != toc) { // find closest <a>
-        if (el.tagName.toLowerCase() == "a") {
-          toggleSidebar(false);
+        if (el.tagName.toLowerCase() === "a") {
+          toggleSidebar(created, false);
           return;
         }
-        el = el.parentElement;
+        el = el.parentElement!;
       }
     }
   }, false);
-}
-else {
-  console.warn("Can't find Table of Contents. Please use <nav id='toc'> around the ToC.");
-}
-
-/* Wrap tables in case they overflow */
-const tables = document.querySelectorAll(':not(.overlarge) > table.data, :not(.overlarge) > table.index');
-const numTables = tables.length;
-for (let i = 0; i < numTables; i++) {
-  const table = tables[i];
-  const wrapper = document.createElement('div');
-  wrapper.className = 'overlarge';
-  table.parentNode.insertBefore(wrapper, table);
-  wrapper.appendChild(table);
-}
-
 }

--- a/src/respec/sidebar.ts
+++ b/src/respec/sidebar.ts
@@ -8,15 +8,15 @@
 
 export default function () {
 
-var collapseSidebarText = '<span aria-hidden="true">←</span> '
+const collapseSidebarText = '<span aria-hidden="true">←</span> '
                         + '<span>Collapse Sidebar</span>';
-var expandSidebarText   = '<span aria-hidden="true">→</span> '
+const expandSidebarText   = '<span aria-hidden="true">→</span> '
                         + '<span>Pop Out Sidebar</span>';
-var tocJumpText         = '<span aria-hidden="true">↑</span> '
+const tocJumpText         = '<span aria-hidden="true">↑</span> '
                         + '<span>Jump to Table of Contents</span>';
 
-var sidebarMedia = window.matchMedia('screen and (min-width: 78em)');
-var autoToggle   = function(e){ toggleSidebar(e.matches) };
+const sidebarMedia = window.matchMedia('screen and (min-width: 78em)');
+const autoToggle   = function(e){ toggleSidebar(e.matches) };
 if(sidebarMedia.addListener) {
   sidebarMedia.addListener(autoToggle);
 }
@@ -27,18 +27,18 @@ function toggleSidebar(on) {
   }
 
   /* Don't scroll to compensate for the ToC if we're above it already. */
-  var headY = 0;
-  var head = document.querySelector('.head');
+  let headY = 0;
+  const head = document.querySelector('.head');
   if (head) {
     // terrible approx of "top of ToC"
     headY += head.offsetTop + head.offsetHeight;
   }
-  var skipScroll = window.scrollY < headY;
+  const skipScroll = window.scrollY < headY;
 
-  var toggle = document.getElementById('toc-toggle');
-  var tocNav = document.getElementById('toc');
+  const toggle = document.getElementById('toc-toggle');
+  const tocNav = document.getElementById('toc');
   if (on) {
-    var tocHeight = tocNav.offsetHeight;
+    const tocHeight = tocNav.offsetHeight;
     document.body.classList.add('toc-sidebar');
     document.body.classList.remove('toc-inline');
     toggle.innerHTML = collapseSidebarText;
@@ -65,7 +65,7 @@ function toggleSidebar(on) {
 
 function createSidebarToggle() {
   /* Create the sidebar toggle in JS; it shouldn't exist when JS is off. */
-  var toggle = document.createElement('a');
+  const toggle = document.createElement('a');
     /* This should probably be a button, but appearance isn't standards-track.*/
   toggle.id = 'toc-toggle';
   toggle.class = 'toc-toggle';
@@ -73,7 +73,7 @@ function createSidebarToggle() {
   toggle.innerHTML = collapseSidebarText;
 
   sidebarMedia.addListener(autoToggle);
-  var toggler = function(e) {
+  const toggler = function(e) {
     e.preventDefault();
     sidebarMedia.removeListener(autoToggle); // persist explicit off states
     toggleSidebar();
@@ -83,7 +83,7 @@ function createSidebarToggle() {
 
 
   /* Get <nav id=toc-nav>, or make it if we don't have one. */
-  var tocNav = document.getElementById('toc-nav');
+  let tocNav = document.getElementById('toc-nav');
   if (!tocNav) {
     tocNav = document.createElement('p');
     tocNav.id = 'toc-nav';
@@ -91,7 +91,7 @@ function createSidebarToggle() {
     document.body.insertBefore(tocNav, document.body.firstChild);
   }
   /* While we're at it, make sure we have a Jump to Toc link. */
-  var tocJump = document.getElementById('toc-jump');
+  let tocJump = document.getElementById('toc-jump');
   if (!tocJump) {
     tocJump = document.createElement('a');
     tocJump.id = 'toc-jump';
@@ -103,7 +103,7 @@ function createSidebarToggle() {
   tocNav.appendChild(toggle);
 }
 
-var toc = document.getElementById('toc');
+const toc = document.getElementById('toc');
 if (toc) {
   createSidebarToggle();
   toggleSidebar(sidebarMedia.matches);
@@ -113,7 +113,7 @@ if (toc) {
       then auto-close the sidebar once you click on something in there. */
   toc.addEventListener('click', function(e) {
     if(document.body.classList.contains('toc-sidebar') && !sidebarMedia.matches) {
-      var el = e.target;
+      let el = e.target;
       while (el != toc) { // find closest <a>
         if (el.tagName.toLowerCase() == "a") {
           toggleSidebar(false);
@@ -129,11 +129,11 @@ else {
 }
 
 /* Wrap tables in case they overflow */
-var tables = document.querySelectorAll(':not(.overlarge) > table.data, :not(.overlarge) > table.index');
-var numTables = tables.length;
-for (var i = 0; i < numTables; i++) {
-  var table = tables[i];
-  var wrapper = document.createElement('div');
+const tables = document.querySelectorAll(':not(.overlarge) > table.data, :not(.overlarge) > table.index');
+const numTables = tables.length;
+for (let i = 0; i < numTables; i++) {
+  const table = tables[i];
+  const wrapper = document.createElement('div');
   wrapper.className = 'overlarge';
   table.parentNode.insertBefore(wrapper, table);
   wrapper.appendChild(table);


### PR DESCRIPTION
- **refactor: `var` → `const`/`let`**
- **fix: Get rid of the weird scroll on start up**

原先初次打开页面时不在页面顶端，并且原地刷新会滚动位置，特别是窄屏。
