### PR TITLE
Record new issues in 2025-08

### DIFF
--- a/main.typ
+++ b/main.typ
@@ -204,6 +204,7 @@
 
 #level.advanced
 #issue("typst#366")
+#issue("typst#6737")
 #workaround("https://typst-doc-cn.github.io/guide/FAQ/equation-chinese-font.html")
 
 #babel(


### PR DESCRIPTION
Clear all issues in #22 at present.

https://github.com/typst/typst/issues/6774
https://github.com/typst/typst/issues/6735
https://github.com/typst/typst/issues/6737

破折号一节举的例子刚好与地区无关——无论间隔号基准宽度是一个字还是半个字（[可能有地区差异](https://github.com/w3c/clreq/issues/705)），此例因为间隔号、叹号要避头，间隔号都得缩成半个字。

